### PR TITLE
Add the Stencila Node.js host for Jupyter execution context support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR ${STENCILA_DIR}
 ADD package.json package.json
 RUN npm install
 ADD stencila.js stencila.js
+ADD stencila-host.js stencila-host.js
 ADD index.html index.html
 ADD app.js app.js
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,35 @@ Relevant path configurations comprise the local storage path _as well as_ the UR
 
 The `Dockerfile` installs our helper npm package and adds + configures the `nbserverproxy` tool (see `requirements.txt` and `jupyter_notebook_config.py`).
 
+
+### Connecting Stencila to Jupyter kernels
+
+Stencila has "execution contexts" (the equivalent of Jupyter's "kernels") for R, Python, SQL, Javascript (in the browser), and Node.js. Execution contexts differ from kernels in a number of ways including local execution and dependency analysis of cells. Both of these are necessary for the reactive, functional execution model of Stencila Articles and Sheets.
+
+We could install these execution contexts in the Docker image. However, Stencila also has a `JupyterContext` which acts as a bridge between Stencila's API and Jupyter kernels. So, since the base `jupyter/minimal-notebook` image already has a Jupyter kernel for Python installed it we decided to use that. This does mean however, that some of the reactive aspects of the Stencila UI won't work as expected. Also the `JupyterContext` is not well developed or tested.
+
+We have included the [`stencila-node`](https://www.npmjs.com/package/stencila-node) Node.js package in the Docker image which provides the `JupyterContext` as well as a `NodeContext` (for executing Javascript) and a `SqliteContext` (for executing SQL) .
+
+
+## Development
+
+- Build the Docker image:
+
+```bash
+docker build --tag jupyter-dar .
+```
+
+- Run the Docker image:
+
+```bash
+docker run -p 8888:8888 jupyter-dar
+```
+
+- Login by visiting the tokenized URL displayed e.g. `http://localhost:8888/?token=99a7bc13...`
+
+- Go to http://localhost:8888/stencila/
+
+
 ## License
 
 BSD 3-Clause License

--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@
   window.addEventListener('load', () => {
     substance.substanceGlobals.DEBUG_RENDERING = substance.platform.devtools;
     stencila.StencilaWebApp.mount({
-      archiveId: substance.getQueryStringParam('archive') || 'kitchen-sink',
+      archiveId: substance.getQueryStringParam('archive') || 'py-jupyter',
       storageType: substance.getQueryStringParam('storage') || 'fs',
       storageUrl: substance.getQueryStringParam('storageUrl') || './archives'
     }, window.document.body);

--- a/archive/py-jupyter/py-jupyter.ipynb.jats.xml
+++ b/archive/py-jupyter/py-jupyter.ipynb.jats.xml
@@ -52,7 +52,8 @@ y = np.random.rand(N)
 colors = np.random.rand(N)
 area = np.pi * (15 * np.random.rand(N))**2  # 0 to 15 point radii
 
-plt.scatter(x, y, s=area, c=colors, alpha=0.5)</code>
+plt.scatter(x, y, s=area, c=colors, alpha=0.5)
+plt.show()</code>
       <code specific-use="output" language="json">{}</code>
       </alternatives>
       </named-content>

--- a/archive/py-jupyter/py-jupyter.ipynb.jats.xml
+++ b/archive/py-jupyter/py-jupyter.ipynb.jats.xml
@@ -33,7 +33,7 @@
       <title>Code cells</title>
       <p>Code cells in notebooks are imported without loss. Stencila&#x2019;s user interface currently differs from Jupyter in that code cells are executed on update while you are typing. This produces a very reactive user experience but is inappropriate for more compute intensive, longer running code cells. We are currently working on improving this to allowing users to decide to execute cells explicitly (e.g.&#xA0;using <monospace>Ctrl+Enter</monospace>).</p>
       <code specific-use="cell"><named-content><alternatives>
-          <code specific-use="source" language="py" executable="yes">import sys
+          <code specific-use="source" language="pyjp" executable="yes">import sys
 import time
 &apos;Hello this is Python %s.%s and it is %s&apos; % (sys.version_info[0], sys.version_info[1], time.strftime(&apos;%c&apos;))</code>
       <code specific-use="output" language="json">{}</code>
@@ -42,7 +42,7 @@ import time
       </code>
       <p>Stencila also support Jupyter code cells that produce plots. The cell below produces a simple plot based on the example from <ext-link ext-link-type="uri" xlink:href="https://matplotlib.org/examples/shapes_and_collections/scatter_demo.html">the Matplotlib website</ext-link>. Try changing the code below (for example, the variable <monospace>N</monospace>).</p>
       <code specific-use="cell"><named-content><alternatives>
-          <code specific-use="source" language="py" executable="yes">import numpy as np
+          <code specific-use="source" language="pyjp" executable="yes">import numpy as np
 import matplotlib.pyplot as plt
 
 N = 50

--- a/index.html
+++ b/index.html
@@ -16,7 +16,9 @@
     <script type="text/javascript" src="./node_modules/stencila/dist/env.js"></script>
     <script type="text/javascript" src="./app.js"></script>
     <script type="text/javascript">
-        window.STENCILA_HOSTS = window.location.origin + '/stencila-host'
+        // Set the URL for the Stencila host based on the current window's URL which on Binder looks like:
+        // https://hub.mybinder.org/user/nokome-jupyter-dar-xufgzr0d/stencila/?token=c1KzGj7XRg-Gyur8rr-U3pQ
+        window.STENCILA_HOSTS = (window.location.origin + window.location.pathname).replace('/stencila/', '/stencila-host')
     </script>
   </head>
   <body></body>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
     <script type="text/javascript" src="./node_modules/stencila/dist/vfs.js"></script>
     <script type="text/javascript" src="./node_modules/stencila/dist/env.js"></script>
     <script type="text/javascript" src="./app.js"></script>
+    <script type="text/javascript">
+        window.STENCILA_HOSTS = window.location.origin + '/stencila-host'
+    </script>
   </head>
   <body></body>
 </html>

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -22,11 +22,34 @@ class StencilaProxyHandler(SuperviseAndProxyHandler):
         ]
 
 
+class StencilaHostProxyHandler(SuperviseAndProxyHandler):
+
+    name = 'stencila-host'
+
+    def get_env(self):
+        return {
+            'STENCILA_HOST_PORT': str(self.port)
+        }
+
+    def get_cmd(self):
+        return [
+            'sh', '-c', 'cd "$STENCILA_DIR"; node stencila-host.js',
+        ]
+
+
 def add_handlers(app):
     app.web_app.add_handlers('.*', [
         (
             app.base_url + 'stencila/(.*)',
             StencilaProxyHandler,
+            dict(state=dict(
+                base_url=app.base_url,
+                notebook_dir=app.notebook_dir,
+            )),
+
+        ), (
+            app.base_url + 'stencila-host/(.*)',
+            StencilaHostProxyHandler,
             dict(state=dict(
                 base_url=app.base_url,
                 notebook_dir=app.notebook_dir,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "javascript dependencies for jupyter-dar",
   "main": "stencila.js",
   "dependencies": {
-    "stencila": "^0.28.0"
+    "stencila": "0.28.1-preview.2",
+    "stencila-node": "stencila/node#jupyter-context"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "stencila.js",
   "dependencies": {
     "stencila": "0.28.1-preview.2",
-    "stencila-node": "stencila/node#jupyter-context"
+    "stencila-node": "stencila/node#9b619f8f191474dc362934993199642acdf81ae2"
   },
   "devDependencies": {},
   "scripts": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 nbserverproxy
+numpy
+matplotlib

--- a/stencila-host.js
+++ b/stencila-host.js
@@ -1,0 +1,10 @@
+const stencila = require("stencila-node");
+
+// Get the port passed here from the `nbserverproxy.hanglers.SuperviseAndProxyHandler`
+const port = parseInt(process.env.STENCILA_HOST_PORT || '2000')
+
+// Run the Stencila execution host without
+// any authentication (handled by Jupyter)
+process.env.STENCILA_AUTH = 'false'
+
+stencila.run({ port })


### PR DESCRIPTION
Thanks so much for choosing this as a project for the eLife sprint! We've worked on a couple of aspects of Stencila-Jupyter integration (file converters and a `JupyterContext`) but this is the first real test of them.

This PR add's the `JupyterContext` which allows for cells to be executed in a Jupyter Python kernel. More details in the README.

I'm going to continue work on the `JupyterContext` over in `stencila/node` to better support different mime types for execution results.