### PR TITLE
Use recent version of stencila/r directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR ${STENCILA_DIR}
 ADD package.json package.json
 RUN npm install
 ADD stencila.js stencila.js
-ADD stencila-host.js stencila-host.js
+ADD stencila-host.R stencila-host.R
 ADD index.html index.html
 ADD app.js app.js
 
@@ -19,7 +19,6 @@ WORKDIR ${HOME}
 ADD requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt
 
-# https://github.com/r-lib/devtools/issues/1722
 ENV TAR /bin/tar
 ADD install.R install.R
 RUN Rscript install.R

--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@
   window.addEventListener('load', () => {
     substance.substanceGlobals.DEBUG_RENDERING = substance.platform.devtools;
     stencila.StencilaWebApp.mount({
-      archiveId: substance.getQueryStringParam('archive') || 'py-jupyter',
+      archiveId: substance.getQueryStringParam('archive') || 'r-markdown',
       storageType: substance.getQueryStringParam('storage') || 'fs',
       storageUrl: substance.getQueryStringParam('storageUrl') || './archives'
     }, window.document.body);

--- a/install.R
+++ b/install.R
@@ -1,8 +1,5 @@
 library(devtools)
 options(unzip = "internal")
-# see https://github.com/stencila/r/blob/master/README.md
-#devtools::install_github("stencila/r")
-# https://github.com/stencila/r/issues/21
-devtools::install_github("nuest/r")
-stencila:::install()
-# install.packages("tidyverse")
+
+devtools::install_github("stencila/r", ref="93cdeadc05b3229f8f42558fc7cb6822031a1f52")
+stencila::register()

--- a/install.R
+++ b/install.R
@@ -1,5 +1,5 @@
 library(devtools)
 options(unzip = "internal")
 
-devtools::install_github("stencila/r", ref="93cdeadc05b3229f8f42558fc7cb6822031a1f52")
+devtools::install_github("stencila/r", ref = "f220361438432abca968d2e76a4efe7c5ddde7f1")
 stencila::register()

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -33,7 +33,7 @@ class StencilaHostProxyHandler(SuperviseAndProxyHandler):
 
     def get_cmd(self):
         return [
-            'sh', '-c', 'cd "$STENCILA_DIR"; node stencila-host.js',
+            'sh', '-c', 'cd "$STENCILA_DIR"; Rscript stencila-host.R',
         ]
 
 

--- a/stencila-host.R
+++ b/stencila-host.R
@@ -1,0 +1,9 @@
+# Get the port passed here from the `nbserverproxy.hanglers.SuperviseAndProxyHandler`
+port <- as.integer(Sys.getenv("STENCILA_HOST_PORT"))
+if (is.na(port)) port <- 2000
+
+# Run the Stencila execution host without
+# any authentication (handled by Jupyter)
+Sys.setenv(STENCILA_AUTH = "false")
+
+stencila::run(port=port)

--- a/stencila.js
+++ b/stencila.js
@@ -23,5 +23,5 @@ console.log("DAR public URL: %s", serverUrl);
 console.log("Serving stencila on :%s", port);
 
 server.use("/", express.static(staticDir));
-server.use(express.logger('dev'));
+//server.use(express.logger('dev'));
 server.listen(port);


### PR DESCRIPTION
@nuest and @minrk : as I mentioned I had some upgrades and general tidy ups to do on the `RContext` and the `Host` in the `stencila/r` package. Still some more to do but this at least works.

As an experiment I have added the file `stencila-host.R` which runs the host in the R package. If you only want R in your documents then this is an option (and the dependency on `stencila-node` could be dropped). But that was mainly an experiment to see if it worked. Ideally you would still have the `stencila-node` host as the "primary" host since it provides other contexts, including the `RContext` if installed.