### PR TITLE
Use UTF8 encoding when reading README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setuptools.setup(
     url="https://github.com/minrk/" + name,
     author="Min RK, Daniel Nüst, Ryan Lovett",
     description="Jupyter extension to proxy Stencila",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     cmdclass={"build_py": build_npm_py},


### PR DESCRIPTION
Building this Dockerfile: 

```Dockerfile
FROM ubuntu@sha256:5f4bdc3467537cbbe563e80db2c3ec95d548a9145d64453b06939c4592d67b6d

RUN apt-get update \
 && apt-get install -y \
      python3 \
      python3-pip \
      nodejs \
      npm \
 && apt-get autoremove -y \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*

RUN pip3 install nbstencilaproxy==0.1.1
```

Causes the following error:

```
Step 3/3 : RUN pip3 install nbstencilaproxy==0.1.1
 ---> Running in 4501705aed05
Collecting nbstencilaproxy==0.1.1
  Downloading https://files.pythonhosted.org/packages/2b/88/7370fbd6517f481ff96e007e482c89739d2c798fab04a258c2fceca96aca/nbstencilaproxy-0.1.1.tar.gz (296kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-2osq6fcj/nbstencilaproxy/setup.py", line 55, in <module>
        long_description=open("README.md").read(),
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1745: ordinal not in range(128)

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-2osq6fcj/nbstencilaproxy/
The command '/bin/sh -c pip3 install nbstencilaproxy==0.1.1' returned a non-zero code: 1
```

This patch fixes that problem. Curiously this error did not occur for me when doing `pip3 install --user  nbstencilaproxy==0.1.1` locally on Ubuntu 16.04.
