### PR TITLE
Increase request timeout

### DIFF
--- a/nbstencilaproxy/handlers.py
+++ b/nbstencilaproxy/handlers.py
@@ -49,6 +49,15 @@ class StencilaHostProxyHandler(SuperviseAndProxyHandler):
     def get_cmd(self):
         return ["node", _find_stencila_js("stencila-host.js")]
 
+    def proxy_request_options(self):
+        """Increase the request timeout to avoid 599 errors when executing
+        long running cells"""
+        options = super().proxy_request_options()
+        options.update(dict(
+            request_timeout=3600
+        ))
+        return options
+
 
 def setup_handlers(app):
     app.log.info("Enabling stencila proxy")

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setuptools.setup(
     cmdclass={"build_py": build_npm_py},
     keywords=["Jupyter"],
     classifiers=["Framework :: Jupyter"],
-    install_requires=["notebook", "nbserverproxy >= 0.8.3"],
+    install_requires=["notebook", "nbserverproxy >= 0.8.6"],
+    dependency_links=['https://github.com/nokome/nbserverproxy/tarball/master#egg=nbserverproxy-0.8.6'],
     package_data={"nbstencilaproxy": ["static/**", "node_modules/**"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setuptools.setup(
     cmdclass={"build_py": build_npm_py},
     keywords=["Jupyter"],
     classifiers=["Framework :: Jupyter"],
-    install_requires=["notebook", "nbserverproxy >= 0.8.6"],
-    dependency_links=['https://github.com/nokome/nbserverproxy/tarball/master#egg=nbserverproxy-0.8.6'],
+    install_requires=["notebook", "nbserverproxy >= 0.8.5"],
     package_data={"nbstencilaproxy": ["static/**", "node_modules/**"]},
 )


### PR DESCRIPTION
Currently executing cells in a Stencila  document that run for longer than 20s (the tornado default) will fail with status code 500 and message "Timeout during request". e.g.

```python
import time
time.sleep(25)
```

This PR (arbitrarily) increases the timeout to 1hr. It relies on this PR upstream https://github.com/jupyterhub/nbserverproxy/pull/56.

As described in the README, it can be tested in `repo2docker` by modifying the line in `repo2docker/buildpacks/base.py` (note `--process-dependency-links`):

```
${NB_PYTHON_PREFIX}/bin/pip install --no-cache --process-dependency-links https://github.com/nokome/nbstencilaproxy/archive/master.tar.gz &&
```

The `dependency_links` can be dropped in `setup.py`, if the upstream PR gets merged.